### PR TITLE
Upgrade prom-client... again

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "on-finished": "^2.3.0",
-    "prom-client": "^9.0.0",
+    "prom-client": "^10.0.0",
     "url-value-parser": "^1.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-prom-bundle",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "express middleware with popular prometheus metrics in one bundle",
   "main": "src/index.js",
   "keywords": [

--- a/src/index.js
+++ b/src/index.js
@@ -69,10 +69,10 @@ function main(opts) {
   const httpMtricName = opts.httpDurationMetricName || 'http_request_duration_seconds';
 
   const metricTemplates = {
-    'up': () => new promClient.Gauge(
-      'up',
-      '1 = up, 0 = not up'
-    ),
+    'up': () => new promClient.Gauge({
+      name: 'up',
+      help: '1 = up, 0 = not up'
+    }),
     'http_request_duration_seconds': () => {
       const labels = ['status_code'];
       if (opts.includeMethod) {

--- a/src/index.js
+++ b/src/index.js
@@ -81,13 +81,11 @@ function main(opts) {
       if (opts.includePath) {
         labels.push('path');
       }
-      const metric = new promClient.Histogram(
-        httpMtricName,
-        'duration histogram of http responses labeled with: ' + labels.join(', '),
-        labels,
-        {
-          buckets: opts.buckets || [0.003, 0.03, 0.1, 0.3, 1.5, 10]
-        }
+      const metric = new promClient.Histogram({
+        name: httpMtricName,
+        help: 'duration histogram of http responses labeled with: ' + labels.join(', '),
+        labelNames: labels,
+        buckets: opts.buckets || [0.003, 0.03, 0.1, 0.3, 1.5, 10]
       );
       return metric;
     }

--- a/src/index.js
+++ b/src/index.js
@@ -86,7 +86,7 @@ function main(opts) {
         help: 'duration histogram of http responses labeled with: ' + labels.join(', '),
         labelNames: labels,
         buckets: opts.buckets || [0.003, 0.03, 0.1, 0.3, 1.5, 10]
-      );
+      });
       return metric;
     }
   };


### PR DESCRIPTION
Looks like they updated the prom-client again with a super handy new `setDefaultLabels` method.
The upgrade also required a change to how you construct the Histogram and Gauge.
