### PR TITLE
Add custom labels to options

### DIFF
--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -148,11 +148,12 @@ describe('index', () => {
     expect(() => bundle({prefix: 'hello'})).toThrow();
   });
 
-  it('tolerates includePath, includeMethod', done => {
+  it('tolerates includePath, includeMethod, includeCustomLabels', done => {
     const app = express();
     const instance = bundle({
       includePath: true,
-      includeMethod: true
+      includeMethod: true,
+      includeCustomLabels: {foo: 'bar'}
     });
     app.use(instance);
     app.use('/test', (req, res) => res.send('it worked'));
@@ -252,6 +253,27 @@ describe('index', () => {
           .end((err, res) => {
             expect(res.status).toBe(200);
             expect(res.text).not.toMatch(/200/);
+            done();
+          });
+      });
+  });
+
+  it('includeCustomLabels={foo: "bar"} adds foo="bar" label to metrics', done => {
+    const app = express();
+    const instance = bundle({
+      includeCustomLabels: {foo: "bar"}
+    });
+    app.use(instance);
+    app.use('/test', (req, res) => res.send('it worked'));
+    const agent = supertest(app);
+    agent
+      .get('/test')
+      .end(() => {
+        agent
+          .get('/metrics')
+          .end((err, res) => {
+            expect(res.status).toBe(200);
+            expect(res.text).toMatch(/foo="bar"/);
             done();
           });
       });


### PR DESCRIPTION
This PR is in response to github issue #11 

This allows users to add custom labels to their metrics via the following option:
```
{
    includeCustomLabels: {
        foo: 'bar',
        hello: 'world'
    }
}
```

This option will result in output similar to the following:
```
http_request_duration_seconds_count{status_code="200",method="GET",path="/",foo="bar",hello="world"} 1
```

Inclusion of the option is validated using the `hasCustomLabels(opts, strict=true)` function. Currently set in a strict mode this function will throw an error if the option is passed with an invalid datatype.
```
/var/node/express-prom-bundle/src/index.js:54
      throw new Error(
      ^

Error: express-prom-bundle detected invalid data type for option: includeCustomLabels.
Expected: Object
Passed: String
    at hasCustomLabels (/var/node/express-prom-bundle/src/index.js:54:13)
    at Object.metricTemplates.http_request_duration_seconds (/var/node/express-prom-bundle/src/index.js:108:11)
    at main (/var/node/express-prom-bundle/src/index.js:125:42)
    at Object.<anonymous> (/var/node/prom-metrics-test/index.js:11:24)
    at Module._compile (module.js:434:26)
    at Object.Module._extensions..js (module.js:452:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Function.Module.runMain (module.js:475:10)
    at startup (node.js:117:18)
```