### PR TITLE
Add support for clusterMaster option re: #16

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ if (cluster.isMaster) {
         workers.push(worker);
     }
     const metricsApp = express();
-    metricsApp.use('/cluster_metrics', promBundle({clusterMaster: true}));
+    metricsApp.use('/cluster_metrics', promBundle.clusterMetrics());
     metricsApp.listen(9999);
     console.log('metrics listening on 9999'); // call localhost:9999/cluster_metrics for aggregated metrics
 } else {

--- a/README.md
+++ b/README.md
@@ -40,6 +40,28 @@ The order in which the routes are registered is important, since
 You can use this to your advantage to bypass some of the routes.
 See the example below.
 
+## Usage with Node Cluster
+``` javascript
+if (cluster.isMaster) {
+    const numCPUs = Math.max(2, os.cpus().length);
+    const workers: cluster.Worker[] = [];
+    for (let i=1; i < numCPUs; i++) {
+        const worker = forkWorker();
+        workers.push(worker);
+    }
+    const metricsApp = express();
+    metricsApp.use('/cluster_metrics', promBundle({clusterMaster: true}));
+    metricsApp.listen(9999);
+    console.log('metrics listening on 9999'); // call localhost:9999/cluster_metrics for aggregated metrics
+} else {
+    const app = express();
+    app.use(promBundle({includeMethod: true});
+    app.use('/api', require('./api'));
+    app.listen(3000);
+}
+```
+The code the master process runs will expose an API with a single endpoint `/cluster_metrics` which returns an aggregate of all metrics from all the workers.
+
 ## Options
 
 Which labels to include in `http_request_duration_seconds` metric:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "express-prom-bundle",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "method"
   ],
   "scripts": {
-    "test": "node_modules/jasme/run.js"
+    "test": "jasme"
   },
   "author": "Konstantin Pogorelov <or@pluseq.com>",
   "license": "MIT",

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -259,6 +259,20 @@ describe('index', () => {
     });
   });
 
+  describe('usage of clusterMetrics()', () => {
+    it('clusterMetrics returns metrics for aggregator', (done) => {
+        const app = express();
+        app.use('/cluster_metrics', bundle.clusterMetrics());
+        const agent = supertest(app);
+        agent
+        .get('/metrics_cluster')
+        .expect(200)
+        .end((err, res) => {
+          done(err);
+        });
+    });
+  });
+
   it('formatStatusCode can be overridden', done => {
     const app = express();
     const instance = bundle({

--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,7 @@ function clusterMetrics() {
         if (aggregatorRegistry) {
           aggregatorRegistry.clusterMetrics((err, clusterMetrics) => {
               if (err) {
-                  console.log(err);
+                  console.error(err);
               }
               res.set('Content-Type', aggregatorRegistry.contentType);
               res.send(clusterMetrics);


### PR DESCRIPTION
Adding this middleware with the `clusterMaster: true` opt allows you to host a separate endpoint on whatever port you want and expose aggregated metrics for all routes