### PR TITLE
Feature/add metrics type summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Extra transformation callbacks:
 Other options:
 
 * **buckets**: buckets used for `http_request_duration_seconds` histogram
+* **percentiles**: percentiles used for `http_request_duration_seconds` summary
 * **autoregister**: if `/metrics` endpoint should be registered. (Default: **true**)
 * **promClient**: options for promClient startup, e.g. **collectDefaultMetrics**. This option was added
   to keep `express-prom-bundle` runnable using confit (e.g. with kraken.js) without writing any JS code,

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Internally it uses **prom-client**. See: https://github.com/siimon/prom-client
 Included metrics:
 
 * `up`: normally is just 1
-* `http_request_duration_seconds`: http latency histogram labeled with `status_code`, `method` and `path`
+* `http_request_duration_seconds`: http latency histogram/summary labeled with `status_code`, `method` and `path`
 
 ## Install
 
@@ -63,6 +63,12 @@ if (cluster.isMaster) {
 The code the master process runs will expose an API with a single endpoint `/cluster_metrics` which returns an aggregate of all metrics from all the workers.
 
 ## Options
+
+Metrics type:
+
+* **metricsType**: two metrics type are supported for `http_request_duration_seconds` metric: [histogram](https://prometheus.io/docs/concepts/metric_types/#histogram) and [summary](https://prometheus.io/docs/concepts/metric_types/#summary),  default: **histogram**
+
+
 
 Which labels to include in `http_request_duration_seconds` metric:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "express-prom-bundle",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -186,6 +186,48 @@ describe('index', () => {
       });
   });
 
+  it('metrics type summary works', done => {
+    const app = express();
+    const bundled = bundle({
+      metricsType: 'summary',
+      percentiles: [0.5, 0.85, 0.99]
+    });
+    app.use(bundled);
+    app.use('/test', (req, res) => res.send('it worked'));
+
+    const agent = supertest(app);
+    agent.get('/test').end(() => {
+      agent
+        .get('/metrics')
+        .end((err, res) => {
+          expect(res.status).toBe(200);
+          expect(res.text).toMatch(/quantile="0.85"/);
+          done();
+        });
+    });
+  });
+
+  it('metrics type histogram works', done => {
+    const app = express();
+    const bundled = bundle({
+      metricsType: 'histogram',
+      buckets: [10, 100]
+    });
+    app.use(bundled);
+    app.use('/test', (req, res) => res.send('it worked'));
+
+    const agent = supertest(app);
+    agent.get('/test').end(() => {
+      agent
+        .get('/metrics')
+        .end((err, res) => {
+          expect(res.status).toBe(200);
+          expect(res.text).toMatch(/le="100"/);
+          done();
+        });
+    });
+  });
+
   describe('usage of normalizePath()', () => {
 
     it('normalizePath can be replaced gloablly', done => {
@@ -419,45 +461,5 @@ describe('index', () => {
           done();
         });
     }, 6000);
-
-    it('metrics type summary works', done => {
-      const app = express();
-      const bundled = bundle({
-        metricsType: 'summary'
-      });
-      app.use(bundled);
-      app.use('/test', (req, res) => res.send('it worked'));
-
-      const agent = supertest(app);
-      agent.get('/test').end(() => {
-        agent
-          .get('/metrics')
-          .end((err, res) => {
-            expect(res.status).toBe(200);
-            expect(res.text).toMatch(/quantile="/);
-            done();
-          });
-      });
-    });
-
-    it('metrics type histogram works', done => {
-      const app = express();
-      const bundled = bundle({
-        metricsType: 'histogram'
-      });
-      app.use(bundled);
-      app.use('/test', (req, res) => res.send('it worked'));
-
-      const agent = supertest(app);
-      agent.get('/test').end(() => {
-        agent
-          .get('/metrics')
-          .end((err, res) => {
-            expect(res.status).toBe(200);
-            expect(res.text).toMatch(/le="/);
-            done();
-          });
-      });
-    });
   });
 });

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -190,7 +190,7 @@ describe('index', () => {
     const app = express();
     const bundled = bundle({
       metricsType: 'summary',
-      percentiles: [0.5, 0.85, 0.99]
+      percentiles: [0.5, 0.85, 0.99],
     });
     app.use(bundled);
     app.use('/test', (req, res) => res.send('it worked'));
@@ -211,7 +211,7 @@ describe('index', () => {
     const app = express();
     const bundled = bundle({
       metricsType: 'histogram',
-      buckets: [10, 100]
+      buckets: [10, 100],
     });
     app.use(bundled);
     app.use('/test', (req, res) => res.send('it worked'));
@@ -226,6 +226,12 @@ describe('index', () => {
           done();
         });
     });
+  });
+
+  it('throws on unknown metricType ', () => {
+    expect(() => {
+      bundle({metricsType: 'hello',});
+    }).toThrow();
   });
 
   describe('usage of normalizePath()', () => {

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -419,5 +419,45 @@ describe('index', () => {
           done();
         });
     }, 6000);
+
+    it('metrics type summary works', done => {
+      const app = express();
+      const bundled = bundle({
+        metricsType: 'summary'
+      });
+      app.use(bundled);
+      app.use('/test', (req, res) => res.send('it worked'));
+
+      const agent = supertest(app);
+      agent.get('/test').end(() => {
+        agent
+          .get('/metrics')
+          .end((err, res) => {
+            expect(res.status).toBe(200);
+            expect(res.text).toMatch(/quantile="/);
+            done();
+          });
+      });
+    });
+
+    it('metrics type histogram works', done => {
+      const app = express();
+      const bundled = bundle({
+        metricsType: 'histogram'
+      });
+      app.use(bundled);
+      app.use('/test', (req, res) => res.send('it worked'));
+
+      const agent = supertest(app);
+      agent.get('/test').end(() => {
+        agent
+          .get('/metrics')
+          .end((err, res) => {
+            expect(res.status).toBe(200);
+            expect(res.text).toMatch(/le="/);
+            done();
+          });
+      });
+    });
   });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -115,7 +115,7 @@ function main(opts) {
           labelNames: labels,
           percentiles: opts.percentiles || [0.5, 0.75, 0.95, 0.98, 0.99, 0.999]
         });
-       } else if (opts.metricsType === 'histogram') {
+       } else if (opts.metricsType === 'histogram' || !opts.metricsType) {
         return new promClient.Histogram({
           name: httpMetricName,
           help: 'duration histogram of http responses labeled with: ' + labels.join(', '),

--- a/src/index.js
+++ b/src/index.js
@@ -108,20 +108,23 @@ function main(opts) {
         labels.push.apply(labels, Object.keys(opts.customLabels));
       }
 
-      const metric = opts.metricsType === 'summary' ?
-        new promClient.Summary({
+      if (opts.metricsType === 'summary') {
+        return new promClient.Summary({
           name: httpMetricName,
           help: 'duration summary of http responses labeled with: ' + labels.join(', '),
           labelNames: labels,
           percentiles: opts.percentiles || [0.5, 0.75, 0.95, 0.98, 0.99, 0.999]
-        }) :
-        new promClient.Histogram({
+        });
+       } else if (opts.metricsType === 'histogram') {
+        return new promClient.Histogram({
           name: httpMetricName,
           help: 'duration histogram of http responses labeled with: ' + labels.join(', '),
           labelNames: labels,
           buckets: opts.buckets || [0.003, 0.03, 0.1, 0.3, 1.5, 10]
         });
-      return metric;
+      } else {
+        throw new Error('metricsType option must be histogram or summary');
+      }
     }
   };
 

--- a/src/index.js
+++ b/src/index.js
@@ -62,6 +62,7 @@ function main(opts) {
       includeStatusCode: true,
       normalizePath: main.normalizePath,
       formatStatusCode: main.normalizeStatusCode,
+      metricsType: 'histogram',
       promClient: {}
     },
     opts
@@ -106,12 +107,20 @@ function main(opts) {
       if (opts.customLabels){
         labels.push.apply(labels, Object.keys(opts.customLabels));
       }
-      const metric = new promClient.Histogram({
-        name: httpMetricName,
-        help: 'duration histogram of http responses labeled with: ' + labels.join(', '),
-        labelNames: labels,
-        buckets: opts.buckets || [0.003, 0.03, 0.1, 0.3, 1.5, 10]
-      });
+
+      const metric = opts.metricsType === 'summary' ?
+        new promClient.Summary({
+          name: httpMetricName,
+          help: 'duration summary of http responses labeled with: ' + labels.join(', '),
+          labelNames: labels,
+          percentiles: [0.5, 0.75, 0.95, 0.98, 0.99, 0.999]
+        }) :
+        new promClient.Histogram({
+          name: httpMetricName,
+          help: 'duration histogram of http responses labeled with: ' + labels.join(', '),
+          labelNames: labels,
+          buckets: opts.buckets || [0.003, 0.03, 0.1, 0.3, 1.5, 10]
+        });
       return metric;
     }
   };

--- a/src/index.js
+++ b/src/index.js
@@ -113,7 +113,7 @@ function main(opts) {
           name: httpMetricName,
           help: 'duration summary of http responses labeled with: ' + labels.join(', '),
           labelNames: labels,
-          percentiles: [0.5, 0.75, 0.95, 0.98, 0.99, 0.999]
+          percentiles: opts.percentiles || [0.5, 0.75, 0.95, 0.98, 0.99, 0.999]
         }) :
         new promClient.Histogram({
           name: httpMetricName,


### PR DESCRIPTION
feature: add metrics type summary for http_request_duration_seconds metrics

add new option: metricsType - {histogram | summary} - default: histogram
add new option: percentiles - array of floats - default: [0.5, 0.75, 0.95, 0.98, 0.99, 0.999]

Issue #23
Closes #23