### PR TITLE
pass maxAgeSeconds & ageBuckets to summary metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Other options:
 
 * **buckets**: buckets used for `http_request_duration_seconds` histogram
 * **percentiles**: percentiles used for `http_request_duration_seconds` summary
+* **ageBuckets**: ageBuckets configures how many buckets we will have in our sliding window for the summary
+* **maxAgeSeconds**: the maxAgeSeconds will tell how old an bucket can be before it is reset
 * **autoregister**: if `/metrics` endpoint should be registered. (Default: **true**)
 * **promClient**: options for promClient startup, e.g. **collectDefaultMetrics**. This option was added
   to keep `express-prom-bundle` runnable using confit (e.g. with kraken.js) without writing any JS code,

--- a/src/index.js
+++ b/src/index.js
@@ -91,7 +91,7 @@ function main(opts) {
         help: 'duration summary of http responses labeled with: ' + labels.join(', '),
         labelNames: labels,
         percentiles: opts.percentiles || [0.5, 0.75, 0.95, 0.98, 0.99, 0.999],
-        maxAgeSeconds:  opts.percentiles,
+        maxAgeSeconds:  opts.maxAgeSeconds,
         ageBuckets: opts.ageBuckets
       });
     } else if (opts.metricType === 'histogram' || !opts.metricType) {

--- a/src/index.js
+++ b/src/index.js
@@ -90,7 +90,9 @@ function main(opts) {
         name: httpMetricName,
         help: 'duration summary of http responses labeled with: ' + labels.join(', '),
         labelNames: labels,
-        percentiles: opts.percentiles || [0.5, 0.75, 0.95, 0.98, 0.99, 0.999]
+        percentiles: opts.percentiles || [0.5, 0.75, 0.95, 0.98, 0.99, 0.999],
+        maxAgeSeconds:  opts.percentiles,
+        ageBuckets: opts.ageBuckets
       });
     } else if (opts.metricType === 'histogram' || !opts.metricType) {
       return new promClient.Histogram({


### PR DESCRIPTION
To enable the sliding window functionality for summaries we need to add maxAgeSeconds and ageBuckets to the config.

see: https://github.com/siimon/prom-client#summary