### PR TITLE
Update index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,9 @@ interface Labels {
 interface Opts {
   autoregister?: boolean;
   buckets?: [number];
-
+  
+  customLabels: { [key: string]: any };
+  
   includeStatusCode?: boolean;
   includeMethod?: boolean;
   includePath?: boolean;
@@ -21,7 +23,7 @@ interface Opts {
   promClient?: DefaultMetricsCollectorConfiguration;
   normalizePath?: NormalizePathRegexs;
   formatStatusCode?: (res: express.Response) => number | string;
-
+  
   transformLabels: (
     labels: Labels,
     req: express.Request,


### PR DESCRIPTION
Custom labels was added as an option but never added to the typescript definition file, breaking the usage during typescript compilation.