### PR TITLE
Fix the definition of the Opts interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,7 @@ interface Labels {
 
 interface Opts {
   autoregister?: boolean;
-  buckets?: [number];
+  buckets?: number[];
 
   customLabels?: { [key: string]: any };
 


### PR DESCRIPTION
The `buckets` property was defined as a `Tuple` (`[number]`) instead of an Array (`number[]`).