### PR TITLE
feat: add excludeFn

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Which labels to include in `http_request_duration_seconds` metric:
 * **includeUp**: include an auxiliary "up"-metric which always returns 1, default: **true**
 * **metricsPath**: replace the `/metrics` route with a **regex** or exact **string**. Note: it is highly recommended to just stick to the default
 * **metricType**: histogram/summary selection. See more details below
+* **excludeRoutes**: Set of String or Regexps which routes should be excluded. No default.
+* **excludeFn**: A function what is evaluated after the request has been served for metrics exclusion. No default.
 
 ### metricType option ###
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "express-prom-bundle",
-  "version": "5.1.4",
+  "version": "5.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -213,19 +213,18 @@ describe('index', () => {
       res.send('it worked');
     });
 
-    app.use('/ignored', (req, res) => res.send('it worked too'));
 
     const agent = supertest(app);
     agent
       .get('/test')
       .end(() => {
         agent
-          .get('/ignored')
+          .get('/unknown')
           .end(() => {
             const metricHashMap = instance.metrics.http_request_duration_seconds.hashMap;
 
             expect(metricHashMap['path:/test,status_code:200']).toBeDefined();
-            expect(metricHashMap['path:/ignored,status_code:200']).not.toBeDefined();
+            expect(metricHashMap['path:/unknown,status_code:404']).not.toBeDefined();
 
             agent
               .get('/metrics')

--- a/src/index.js
+++ b/src/index.js
@@ -141,6 +141,10 @@ function main(opts) {
     const timer = metrics[httpMetricName].startTimer(labels);
 
     onFinished(res, () => {
+      if (opts.excludeFn && opts.excludeFn(req, res)) {
+        return;
+      }
+
       if (opts.includeStatusCode) {
         labels.status_code = opts.formatStatusCode(res, opts);
       }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -13,6 +13,7 @@ declare namespace express_prom_bundle {
   }
 
   type StringOrRegExp = string | RegExp;
+  type ExcludeFn = (req: Request, res: Response) => boolean;
   type NormalizePathEntry = [StringOrRegExp, string];
   type NormalizePathFn = (req: Request, opts: Opts) => string;
   type NormalizeStatusCodeFn = (res: Response) => number | string;
@@ -23,6 +24,7 @@ declare namespace express_prom_bundle {
     buckets?: number[];
 
     excludeRoutes?: StringOrRegExp[];
+    excludeFn?: ExcludeFn;
 
     customLabels?: { [key: string]: any };
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -12,7 +12,8 @@ declare namespace express_prom_bundle {
     [key: string]: string | number;
   }
 
-  type NormalizePathEntry = [string | RegExp, string];
+  type StringOrRegExp = string | RegExp;
+  type NormalizePathEntry = [StringOrRegExp, string];
   type NormalizePathFn = (req: Request, opts: Opts) => string;
   type NormalizeStatusCodeFn = (res: Response) => number | string;
   type TransformLabelsFn = (labels: Labels, req: Request, res: Response) => Labels;
@@ -20,6 +21,8 @@ declare namespace express_prom_bundle {
   interface Opts {
     autoregister?: boolean;
     buckets?: number[];
+
+    excludeRoutes?: StringOrRegExp[];
 
     customLabels?: { [key: string]: any };
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -21,24 +21,36 @@ declare namespace express_prom_bundle {
 
   interface Opts {
     autoregister?: boolean;
-    buckets?: number[];
 
     excludeRoutes?: StringOrRegExp[];
     excludeFn?: ExcludeFn;
 
     customLabels?: { [key: string]: any };
+    transformLabels?: TransformLabelsFn;
 
     includeStatusCode?: boolean;
-    includeMethod?: boolean;
+    formatStatusCode?: NormalizeStatusCodeFn;
+
     includePath?: boolean;
+    normalizePath?: NormalizePathEntry[] | NormalizePathFn;
+
+    includeMethod?: boolean;
     includeUp?: boolean;
+
+    httpDurationMetricName?: string;
 
     metricType?: 'summary' | 'histogram';
     metricsPath?: string;
+
+    // summary
+    percentiles?: number[];
+    maxAgeSeconds?: number;
+    ageBuckets?: number;
+
+    // histogram
+    buckets?: number[];
+
     promClient?: { collectDefaultMetrics?: DefaultMetricsCollectorConfiguration };
-    normalizePath?: NormalizePathEntry[] | NormalizePathFn;
-    formatStatusCode?: NormalizeStatusCodeFn;
-    transformLabels?: TransformLabelsFn;
 
     // https://github.com/disjunction/url-value-parser#options
     urlValueParser?: {

--- a/types/test.ts
+++ b/types/test.ts
@@ -35,6 +35,8 @@ promBundle({
   buckets: [0.1, 0.4, 0.7],
 
   excludeRoutes: ['foo', /foo/],
+  excludeFn: (_req, _res) => false,
+
   includeMethod: true,
   includePath: true,
   customLabels: { year: null },

--- a/types/test.ts
+++ b/types/test.ts
@@ -32,7 +32,11 @@ promClient.register.clear();
 
 // $ExpectType RequestHandler
 promBundle({
-  buckets: [0.1, 0.4, 0.7],
+  metricType: 'summary',
+  metricsPath: '/prometheus',
+  percentiles: [0.1, 0.4, 0.7],
+  maxAgeSeconds: 5,
+  ageBuckets: 10,
 
   excludeRoutes: ['foo', /foo/],
   excludeFn: (_req, _res) => false,
@@ -44,8 +48,6 @@ promBundle({
     ...labels,
     year: new Date().getFullYear()
   }),
-  metricType: 'summary',
-  metricsPath: '/prometheus',
   promClient: {
     collectDefaultMetrics: {
       timeout: 1000
@@ -61,6 +63,13 @@ promBundle({
     ['^/foo', '/example'] // replace /foo with /example
   ],
   formatStatusCode: (res: Response) => res.statusCode + 100
+});
+
+// $ExpectType RequestHandler
+promBundle({
+  buckets: [0.1, 0.4, 0.7],
+  metricType: 'histogram',
+  httpDurationMetricName: 'http_request_duration_seconds'
 });
 
 // TypeScript workaround to write a readonly field

--- a/types/test.ts
+++ b/types/test.ts
@@ -33,6 +33,8 @@ promClient.register.clear();
 // $ExpectType RequestHandler
 promBundle({
   buckets: [0.1, 0.4, 0.7],
+
+  excludeRoutes: ['foo', /foo/],
   includeMethod: true,
   includePath: true,
   customLabels: { year: null },


### PR DESCRIPTION
With this change we could exclude metrics collection after a request has been handled.

Could be useful for not collecting metrics about non existing paths.