### PR TITLE
update types to correct transformLabels

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -15,7 +15,7 @@ declare namespace express_prom_bundle {
   type NormalizePathEntry = [string | RegExp, string];
   type NormalizePathFn = (req: Request, opts: Opts) => string;
   type NormalizeStatusCodeFn = (res: Response) => number | string;
-  type TransformLabelsFn = (labels: Labels, req: Request, res: Response) => Labels;
+  type TransformLabelsFn = (labels: Labels, req: Request, res: Response) => void;
 
   interface Opts {
     autoregister?: boolean;


### PR DESCRIPTION
`transformLabels` should return void as the library expects
the labels object to be modified in place and does not use the return value