### PR TITLE
Allows for customizing promRegistry when creating prom bundle.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Which labels to include in `http_request_duration_seconds` metric:
 * **metricsPath**: replace the `/metrics` route with a **regex** or exact **string**. Note: it is highly recommended to just stick to the default
 * **metricType**: histogram/summary selection. See more details below
 
+
 ### metricType option ###
 
 Two metric types are supported for `http_request_duration_seconds` metric:
@@ -85,6 +86,7 @@ Additional options for **summary**:
 * **promClient**: options for promClient startup, e.g. **collectDefaultMetrics**. This option was added
   to keep `express-prom-bundle` runnable using confit (e.g. with kraken.js) without writing any JS code,
   see [advanced example](https://github.com/jochen-schweizer/express-prom-bundle/blob/master/advanced-example.js)
+* **promRegistry**: Optional `promClient.Registry` instance to attach metrics to. Defaults to global `promClient.register`.
 
 ### More details on includePath option
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "express-prom-bundle",
-  "version": "5.1.4",
+  "version": "5.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,7 +1,7 @@
 // TypeScript Version: 2.8
 
 import { Request, RequestHandler, Response } from 'express';
-import { DefaultMetricsCollectorConfiguration } from 'prom-client';
+import { DefaultMetricsCollectorConfiguration, Registry } from 'prom-client';
 
 export {};
 
@@ -31,6 +31,7 @@ declare namespace express_prom_bundle {
     metricType?: 'summary' | 'histogram';
     metricsPath?: string;
     promClient?: { collectDefaultMetrics?: DefaultMetricsCollectorConfiguration };
+    promRegistry?: Registry,
     normalizePath?: NormalizePathEntry[] | NormalizePathFn;
     formatStatusCode?: NormalizeStatusCodeFn;
     transformLabels?: TransformLabelsFn;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -31,7 +31,7 @@ declare namespace express_prom_bundle {
     metricType?: 'summary' | 'histogram';
     metricsPath?: string;
     promClient?: { collectDefaultMetrics?: DefaultMetricsCollectorConfiguration };
-    promRegistry?: Registry,
+    promRegistry?: Registry;
     normalizePath?: NormalizePathEntry[] | NormalizePathFn;
     formatStatusCode?: NormalizeStatusCodeFn;
     transformLabels?: TransformLabelsFn;

--- a/types/test.ts
+++ b/types/test.ts
@@ -47,6 +47,7 @@ promBundle({
       timeout: 1000
     }
   },
+  promRegistry: new promClient.Registry(),
   urlValueParser: {
     minHexLength: 5,
     extraMasks: [


### PR DESCRIPTION
This PR adds support for a custom registry when configuring the prom bundle. The option is backwards compatible and defaults to `promClient.register` so there should not be issues with existing integrations.