### PR TITLE
fix: regex: stop when match

### DIFF
--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -320,7 +320,7 @@ describe('index', () => {
             .get('/metrics')
             .end((err, res) => {
               expect(res.status).toBe(200);
-              expect(res.text).toMatch(/"\/mocks"/m);
+              expect(res.text).toMatch(/"\/docs"/m);
               done();
             });
         });

--- a/spec/normalizePath.spec.js
+++ b/spec/normalizePath.spec.js
@@ -17,7 +17,7 @@ describe('normalizePath', () => {
         ['[^/]+$','happy'],
       ]
     });
-    expect(result).toBe('/goodbye/world/i/am/finally/happy');
+    expect(result).toBe('/goodbye/world/i/am/finally/free!!!');
   });
 
   it('throws error is bad tuples provided as normalizePath', () => {

--- a/src/normalizePath.js
+++ b/src/normalizePath.js
@@ -19,7 +19,10 @@ module.exports = function(req, opts) {
         throw new Error('Bad tuple provided in normalizePath option, expected: [regex, replacement]');
       }
       const regex = typeof tuple[0] === 'string' ? RegExp(tuple[0]) : tuple[0];
-      path = path.replace(regex, tuple[1]);
+      if (path.match(regex)) {
+        path = path.replace(regex, tuple[1]);
+        break;
+      }
     }
   }
 


### PR DESCRIPTION
Hi, thanks for this lib!

One thing I found to not be very obvious is that the regexps are actually all applied, while I would expect it to stop on the first one that matches.

Stopping on the first one makes it easier to handle "precedence" and also avoids the negative lookaheads and etc to grab things on the middle of the path.

For instance, its hard to do things like this right now:

```js
normalizePath: [
	['^/v(\\d)/projects/.*/alias$', '/v$1/projects/#name/alias'],
	['^/v(\\d)/projects/.*', '/v$1/projects/#name']
]
```

this will actually put all metrics in `/v$1/projects/#name`.

I understand this is a breaking change and I'm willing to change whatever you think its needed, and would also understand if you don't want to accept the PR at all.

Thanks!