### PR TITLE
Update to prom-client v12, requiring Node >=10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
-    - "6"
-    - "8"
     - "10"
+    - "12"
+    - "13"
 notifications:
     email: false
 before_install:

--- a/README.md
+++ b/README.md
@@ -243,7 +243,6 @@ while replacing all HEX values starting from 5 characters and all IP addresses i
             "buckets": [0.1, 1, 5],
             "promClient": {
               "collectDefaultMetrics": {
-                "timeout": 2000
               }
             },
             "urlValueParser": {

--- a/advanced-example.js
+++ b/advanced-example.js
@@ -14,7 +14,6 @@ const bundle = promBundle({
   metricsPath: '/prometheus',
   promClient: {
     collectDefaultMetrics: {
-      timeout: 1000
     }
   },
   urlValueParser: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "express-prom-bundle",
-  "version": "5.1.4",
+  "version": "5.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -711,7 +711,7 @@
         "request": "^2.88.0",
         "strip-json-comments": "^2.0.1",
         "tslint": "5.14.0",
-        "typescript": "^3.5.0-dev.20190427"
+        "typescript": "^3.9.0-dev.20200306"
       },
       "dependencies": {
         "resolve": {
@@ -754,9 +754,9 @@
           }
         },
         "typescript": {
-          "version": "3.5.0-dev.20190427",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.0-dev.20190427.tgz",
-          "integrity": "sha512-JvW5u5YEi1uyNFTTPYIKMI1zgKvvisMBXGGdF/ttHSSnNqSiMvdYuFYCCrJQzG74YWgmwZX6xweJGJO3eoOjNg==",
+          "version": "3.9.0-dev.20200306",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200306.tgz",
+          "integrity": "sha512-JkFUyTm70yUoyJ1uXnIQMp+PL/8D+oHOo9P9ByIknzGERSPNPP08yefNpu8DeleFKhbX3siyIvYLekKS/p2m7g==",
           "dev": true
         }
       }
@@ -2207,9 +2207,9 @@
       "dev": true
     },
     "prom-client": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-11.3.0.tgz",
-      "integrity": "sha512-OqSf5WOvpGZXkfqPXUHNHpjrbEE/q8jxjktO0i7zg1cnULAtf0ET67/J5R4e4iA4MZx2260tzTzSFSWgMdTZmQ==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-12.0.0.tgz",
+      "integrity": "sha512-JbzzHnw0VDwCvoqf8y1WDtq4wSBAbthMB1pcVI/0lzdqHGJI3KBJDXle70XK+c7Iv93Gihqo0a5LlOn+g8+DrQ==",
       "dev": true,
       "requires": {
         "tdigest": "^0.1.1"

--- a/package.json
+++ b/package.json
@@ -36,19 +36,19 @@
     "jasme": "^6.0.0",
     "koa": "^2.6.2",
     "koa-connect": "^2.0.1",
-    "prom-client": "^11.3.0",
+    "prom-client": "^12.0.0",
     "supertest": "^3.3.0",
     "supertest-koa-agent": "^0.3.0",
     "typescript": "^3.4.5"
   },
   "peerDependencies": {
-    "prom-client": "^11.1.2"
+    "prom-client": "^12.0.0"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/jochen-schweizer/express-prom-bundle.git"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=10"
   }
 }

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -443,11 +443,10 @@ describe('index', () => {
     bundle({
       promClient: {
         collectDefaultMetrics: {
-          timeout: 3000
         }
       }
     });
-    expect(spy).toHaveBeenCalledWith({timeout: 3000});
+    expect(spy).toHaveBeenCalledWith({});
   });
 
   describe('usage of clusterMetrics()', () => {

--- a/types/test.ts
+++ b/types/test.ts
@@ -44,7 +44,6 @@ promBundle({
   metricsPath: '/prometheus',
   promClient: {
     collectDefaultMetrics: {
-      timeout: 1000
     }
   },
   urlValueParser: {


### PR DESCRIPTION
* Update to prom-client v12, requiring Node >=10

    v12 drops support for versions of Node.js that are no longer supported
    (as-of January, 2020), and also removes the timeout option from
    collectDefaultMetrics().
