### PR TITLE
Declare that the metricsMiddleware is accessible on the bundle as well

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -44,6 +44,10 @@ declare namespace express_prom_bundle {
     };
   }
 
+  interface Middleware extends RequestHandler {
+    metricsMiddleware: RequestHandler;
+  }
+
   const normalizePath: NormalizePathFn;
   const normalizeStatusCode: NormalizeStatusCodeFn;
 
@@ -55,4 +59,4 @@ interface express_prom_bundle {
   normalizeStatusCode: express_prom_bundle.NormalizeStatusCodeFn;
 }
 
-declare function express_prom_bundle(opts: express_prom_bundle.Opts): RequestHandler;
+declare function express_prom_bundle(opts: express_prom_bundle.Opts): express_prom_bundle.Middleware;

--- a/types/test.ts
+++ b/types/test.ts
@@ -3,7 +3,7 @@ import * as promClient from 'prom-client';
 
 import * as promBundle from 'express-prom-bundle';
 
-// $ExpectType RequestHandler
+// $ExpectType Middleware
 const middleware: RequestHandler = promBundle({ includeMethod: true });
 
 // $ExpectType: string
@@ -11,7 +11,7 @@ middleware.name;
 
 promClient.register.clear();
 
-// $ExpectType RequestHandler
+// $ExpectType Middleware
 promBundle({
   normalizePath: [
     // collect paths like "/customer/johnbobson" as just one "/custom/#name"
@@ -30,7 +30,7 @@ promBundle({
 
 promClient.register.clear();
 
-// $ExpectType RequestHandler
+// $ExpectType Middleware
 promBundle({
   buckets: [0.1, 0.4, 0.7],
   includeMethod: true,


### PR DESCRIPTION
Related-to: #49

---
Note that this only adds the `metricsMiddleware`, not the `promClient`: I didn't feel comfortable to declare that as simply `any`.