### PR TITLE
Improve Typescript definition of bundle output

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,7 +1,7 @@
 // TypeScript Version: 2.8
 
 import { Request, RequestHandler, Response } from 'express';
-import { DefaultMetricsCollectorConfiguration } from 'prom-client';
+import { DefaultMetricsCollectorConfiguration, Registry } from 'prom-client';
 
 export {};
 
@@ -55,4 +55,12 @@ interface express_prom_bundle {
   normalizeStatusCode: express_prom_bundle.NormalizeStatusCodeFn;
 }
 
-declare function express_prom_bundle(opts: express_prom_bundle.Opts): RequestHandler;
+interface metricsMiddleware extends RequestHandler {}
+
+interface PromBundleRequestHandler extends RequestHandler {
+  metricsMiddleware: metricsMiddleware;
+  metric: {[key: string] : any};
+  promClient: Registry;
+}
+  
+declare function express_prom_bundle(opts: express_prom_bundle.Opts): PromBundleRequestHandler;


### PR DESCRIPTION
## Problem

With the current implementation Typescript will **not** compile in the following example as `metricsMiddleware` is not refined as a property in the `main` function output.

```ts
const metricsRequestMiddleware = prometheus({...config, ...{
  includePath: true,
  includeMethod: true,
  autoregister: false,
  promClient: {
      collectDefaultMetrics: {},
  },
}});
const { metricsMiddleware } = metricsRequestMiddleware
```
With the current typescript definition there's no access to certain objects that are already defined in the [index.js file](https://github.com/jochen-schweizer/express-prom-bundle/blob/master/src/index.js#L167-L169).

## Why is this needed

I'm trying to expose the metrics in a different port (and express app) for conventions in the company and as best practice. This PR allows define the metric for an express and expose the metrics in another one.
I.E:
```ts
const metricsRequestMiddleware = prometheus({...config, ...{
  includePath: true,
  includeMethod: true,
  autoregister: false,
  promClient: {
      collectDefaultMetrics: {},
  },
}});

http.use(metricsRequestMiddleware);
monitor.use(metricsRequestMiddleware.metricsMiddleware);

const server: Server = await http.listen(port, () => {
  this.logger.info(`🚀 Server is running in http://localhost:${port}`);
});
const monitor: Server = await monitor.listen(9800, () => {
  this.logger.info(`🚀 Monitor is running in http://localhost:9800/metrics`);
});
```

Thanks