### PR TITLE
Add missing metric name parameter

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -34,6 +34,7 @@ declare namespace express_prom_bundle {
     normalizePath?: NormalizePathEntry[] | NormalizePathFn;
     formatStatusCode?: NormalizeStatusCodeFn;
     transformLabels?: TransformLabelsFn;
+    httpDurationMetricName?: string;
 
     // https://github.com/disjunction/url-value-parser#options
     urlValueParser?: {


### PR DESCRIPTION
This PR adds a missing typescript definition that are part of the optional params.