### PR TITLE
ability to exclude incoming request from metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Which labels to include in `http_request_duration_seconds` metric:
 * **includeUp**: include an auxiliary "up"-metric which always returns 1, default: **true**
 * **metricsPath**: replace the `/metrics` route with a **regex** or exact **string**. Note: it is highly recommended to just stick to the default
 * **metricType**: histogram/summary selection. See more details below
-
+* **filter**: whether the incoming request should be included in the metrics
 
 ### metricType option ###
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Which labels to include in `http_request_duration_seconds` metric:
 * **includeUp**: include an auxiliary "up"-metric which always returns 1, default: **true**
 * **metricsPath**: replace the `/metrics` route with a **regex** or exact **string**. Note: it is highly recommended to just stick to the default
 * **metricType**: histogram/summary selection. See more details below
-* **filter**: whether the incoming request should be included in the metrics
+* **bypass**: Function which takes express request as an argument. Determines whether the given request should be included in the metrics or not, default: **() => false**
 
 ### metricType option ###
 

--- a/src/index.js
+++ b/src/index.js
@@ -131,6 +131,10 @@ function main(opts) {
     : new RegExp('^' + (opts.metricsPath || '/metrics') + '/?$');
 
   const middleware = function (req, res, next) {
+    if (opts.filter && opts.filter(req)) {
+      return next();
+    }
+
     const path = req.originalUrl || req.url; // originalUrl gets lost in koa-connect?
 
     if (opts.autoregister && path.match(metricsMatch)) {

--- a/src/index.js
+++ b/src/index.js
@@ -131,7 +131,7 @@ function main(opts) {
     : new RegExp('^' + (opts.metricsPath || '/metrics') + '/?$');
 
   const middleware = function (req, res, next) {
-    if (opts.filter && opts.filter(req)) {
+    if (opts.bypass && opts.bypass(req)) {
       return next();
     }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -28,7 +28,7 @@ declare namespace express_prom_bundle {
     includePath?: boolean;
     includeUp?: boolean;
 
-    filter?: (req: Request) => boolean;
+    bypass?: (req: Request) => boolean;
 
     metricType?: 'summary' | 'histogram';
     metricsPath?: string;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -28,6 +28,8 @@ declare namespace express_prom_bundle {
     includePath?: boolean;
     includeUp?: boolean;
 
+    filter?: (req: Request) => boolean;
+
     metricType?: 'summary' | 'histogram';
     metricsPath?: string;
     httpDurationMetricName?: string;


### PR DESCRIPTION
Excluding routes by regexp is not handy. Using a filter lambda function is more powerful and generic. It enables instrumenting the api with custom criterias on requests (could be headers, routes etc)
In production scenarios a public api is usually exposed to hackers who try to explore/scan routes, in few days the api has its registry full of 404, 403 metrics. 