### PR TITLE
fix: handle errors from prom-client

### DIFF
--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -409,6 +409,27 @@ describe('index', () => {
       });
   });
 
+  it('handles errors in collectors', done => {
+    const app = express();
+    const instance = bundle({});
+    app.use(instance);
+
+    spyOn(console, 'error'); // mute console.error
+
+    new promClient.Gauge({
+      name: 'kaboom',
+      help: 'this metric explodes',
+      collect() {
+        throw new Error('kaboom!');
+      }
+    });
+
+    supertest(app)
+      .get('/metrics')
+      .expect(500)
+      .end((err) => done(err));
+  });
+
   it('customLabels={foo: "bar"} adds foo="bar" label to metrics', done => {
     const app = express();
     const instance = bundle({


### PR DESCRIPTION
When prom-client returns an error, pass that on to express so the app can return a 500.

`next` wasn't set, so couldn't be called, and we need to have not sent a 200 before calling `next`.

(Also, please switch to a test framework which shows stack traces, so that this would have taken two minutes instead of an hour.)