### PR TITLE
urlValueParser extra and replace masks can be regexp

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -43,8 +43,8 @@ declare namespace express_prom_bundle {
     urlValueParser?: {
       minHexLength?: number;
       minBase64Length?: number;
-      replaceMasks?: string[];
-      extraMasks?: string[];
+      replaceMasks?: (RegExp | string)[];
+      extraMasks?: (RegExp | string)[];
     };
   }
 


### PR DESCRIPTION
https://github.com/disjunction/url-value-parser/blob/master/src/ValueDetector.js#L39

`replaceMasks` and `extraMasks` which are passed down to `url-value-parser` can be either string or RegExp.