### PR TITLE
Describes httpDurationMetricName option on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Which labels to include in `http_request_duration_seconds` metric:
 * **metricsPath**: replace the `/metrics` route with a **regex** or exact **string**. Note: it is highly recommended to just stick to the default
 * **metricType**: histogram/summary selection. See more details below
 * **bypass**: function taking express request as an argument and determines whether the given request should be excluded in the metrics, default: **() => false**
+* **httpDurationMetricName**: Allows you change the name of HTTP duration metric, default: **`http_request_duration_seconds`**.
 
 ### metricType option ###
 


### PR DESCRIPTION
# Problem
I have some other services being exporting Prometheus metrics, but, the name of HTTP duration metric is http_server_requests_seconds, and I have a dimension with my app name. This way is more easy to see all services metrics or only one service metric.

# Solution
I need to change the name of the metric to include my new service as a dimension. Reading the code, I learned that I can do that using httpDurationMetricName option. This was not described in the README, so I'm doing this now.
