### PR TITLE
Add another example for normalizePath

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,17 @@ promBundle.normalizePath = (req, opts) => {
 };
 ```
 
+#### Example 3 (return express route definition):
+
+```javascript
+app.use(promBundle(/* options? */));
+
+promBundle.normalizePath = (req, opts) => {
+  // Return the path of the express route (i.e. /v1/member/:id or /v1/timer/automated/:userid/:timerid")
+  return req.route?.path ?? "NULL";
+};
+```
+
 For more details:
  * [url-value-parser](https://www.npmjs.com/package/url-value-parser) - magic behind automatic path normalization
  * [normalizePath.js](https://github.com/jochen-schweizer/express-prom-bundle/blob/master/src/normalizePath.js) - source code for path processing

--- a/README.md
+++ b/README.md
@@ -142,21 +142,21 @@ promBundle.normalizePath = (req, opts) => {
 };
 ```
 
+For more details:
+ * [url-value-parser](https://www.npmjs.com/package/url-value-parser) - magic behind automatic path normalization
+ * [normalizePath.js](https://github.com/jochen-schweizer/express-prom-bundle/blob/master/src/normalizePath.js) - source code for path processing
+
+
 #### Example 3 (return express route definition):
 
 ```javascript
 app.use(promBundle(/* options? */));
 
 promBundle.normalizePath = (req, opts) => {
-  // Return the path of the express route (i.e. /v1/member/:id or /v1/timer/automated/:userid/:timerid")
+  // Return the path of the express route (i.e. /v1/user/:id or /v1/timer/automated/:userid/:timerid")
   return req.route?.path ?? "NULL";
 };
 ```
-
-For more details:
- * [url-value-parser](https://www.npmjs.com/package/url-value-parser) - magic behind automatic path normalization
- * [normalizePath.js](https://github.com/jochen-schweizer/express-prom-bundle/blob/master/src/normalizePath.js) - source code for path processing
-
 
 ## express example
 


### PR DESCRIPTION
I added a new example for normalizePath as I struggled to get example 2 to work with our routes. Using the routes that are defined in code resulted in the cleanest result for our metrics, especially for our routes that have non-standard id formats in their paths.

Hopefully this example could help save some time for some other users of the package! :)