### PR TITLE
Add a generalized_status_code (2XX, 3XX, ..)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ See the example below.
 Which labels to include in `http_request_duration_seconds` metric:
 
 * **includeStatusCode**: HTTP status code (200, 400, 404 etc.), default: **true**
+* **includeGeneralizedStatusCode**: HTTP status code (2XX, 4XX, 5XX), default: **false**
 * **includeMethod**: HTTP method (GET, PUT, ...), default: **false**
 * **includePath**: URL path (see important details below), default: **false**
 * **customLabels**: an object containing extra labels, e.g. ```{project_name: 'hello_world'}```.

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -449,6 +449,27 @@ describe('index', () => {
       });
   });
 
+  it('includeGeneralizedStatusCode=true adds generalized_status_code label from metrics', done => {
+    const app = express();
+    const instance = bundle({
+      includeGeneralizedStatusCode: true
+    });
+    app.use(instance);
+    app.use('/test', (req, res) => res.status(202).send('it worked'));
+    const agent = supertest(app);
+    agent
+      .get('/test')
+      .end(() => {
+        agent
+          .get('/metrics')
+          .end((err, res) => {
+            expect(res.status).toBe(200);
+            expect(res.text).not.toMatch(/="2XX"/);
+            done();
+          });
+      });
+  });
+
   it('handles errors in collectors', done => {
     const app = express();
     const instance = bundle({});

--- a/src/index.js
+++ b/src/index.js
@@ -50,6 +50,23 @@ function clusterMetrics() {
   return metricsMiddleware;
 }
 
+
+function generalizeStatusCode(status) {
+  if (status >= 200 && status < 300) {
+    return '2XX';
+  }
+  if (status >= 300 && status < 400) {
+    return '3XX';
+  }
+  if (status >= 400 && status < 500) {
+    return '4XX';
+  }
+  if (status >= 500 && status < 600) {
+    return '5XX';
+  }
+  return status;
+}
+
 function main(opts) {
   if (arguments[2] && arguments[1] && arguments[1].send) {
     arguments[1].status(500)
@@ -64,6 +81,7 @@ function main(opts) {
     {
       autoregister: true,
       includeStatusCode: true,
+      includeGeneralizedStatusCode: false,
       normalizePath: main.normalizePath,
       formatStatusCode: main.normalizeStatusCode,
       metricType: 'histogram',
@@ -94,6 +112,9 @@ function main(opts) {
 
   function makeHttpMetric() {
     const labels = ['status_code'];
+    if (opts.includeGeneralizedStatusCode) {
+      labels.push('generalized_status_code');
+    }
     if (opts.includeMethod) {
       labels.push('method');
     }
@@ -196,6 +217,10 @@ function main(opts) {
 
       if (opts.includeStatusCode) {
         labels.status_code = opts.formatStatusCode(res, opts);
+      }
+      if (opts.includeGeneralizedStatusCode) {
+        const status_code = req.status_code || req.statusCode;
+        labels.generalized_status_code = generalizeStatusCode(status_code);
       }
       if (opts.includeMethod) {
         labels.method = req.method;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -23,6 +23,7 @@ declare namespace express_prom_bundle {
     customLabels?: { [key: string]: any };
 
     includeStatusCode?: boolean;
+    includeGeneralizedStatusCode?: boolean;
     includeMethod?: boolean;
     includePath?: boolean;
     includeUp?: boolean;


### PR DESCRIPTION
It is disabled by default. This way, one has the option of storing both the actual status_code and the generalized one.

Before this commit one could provide a custom function to convert the status_code but that would result in the original status_code being lost.