### PR TITLE
Use statuscode 499 for requests that are closed before response is sent

### DIFF
--- a/spec/normalizeStatusCode.spec.js
+++ b/spec/normalizeStatusCode.spec.js
@@ -6,7 +6,11 @@ const normalizeStatusCode = require('../src/normalizeStatusCode');
 describe('normalizeStatusCode', () => {
   it('returns run callback if configured', () => {
     expect(
-      normalizeStatusCode({status_code: 500})
+      normalizeStatusCode({status_code: 500, headersSent: true})
     ).toBe(500);
+  });
+
+  it('returns 499 if headers are not sent', () => {
+    expect(normalizeStatusCode({statusCode: 200, headersSent: false})).toBe(499);
   });
 });

--- a/src/normalizeStatusCode.js
+++ b/src/normalizeStatusCode.js
@@ -1,5 +1,11 @@
 'use strict';
 
+const CLIENT_CLOSED_REQUEST_CODE = 499;
+
 module.exports = function(res) {
-  return res.status_code || res.statusCode;
+  if (res.headersSent) {
+    return res.status_code || res.statusCode;
+  } else {
+    return CLIENT_CLOSED_REQUEST_CODE;
+  }
 };


### PR DESCRIPTION
Sometimes requests are closed by client before the server has a chance to send response.

This happens, for example, when a http proxy in front of the application is configured with a timeout and the node server is too slow to respond. It would also happen if the user's browser goes away without waiting for the response.

Currently such timeouts are counted as 200s by express-prom-bundle. This PR changes that to 499 "Client Closed Request". This way it's possible to tell them apart.