### PR TITLE
Update prom-client to v15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,12 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@opentelemetry/api": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.7.0.tgz",
+      "integrity": "sha512-AdY5wvN0P2vXBi3b29hxZgSFvdhdxPB9+f0B6s//P9Q8nibRWeA3cHm8UmLpio9ABigkVHJ5NMPk+Mz8VCCyrw==",
+      "dev": true
+    },
     "@types/body-parser": {
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.0.tgz",
@@ -124,7 +130,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
       "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ajv": {
       "version": "6.6.2",
@@ -711,7 +718,7 @@
         "request": "^2.88.0",
         "strip-json-comments": "^2.0.1",
         "tslint": "5.14.0",
-        "typescript": "^3.9.0-dev.20200306"
+        "typescript": "next"
       },
       "dependencies": {
         "resolve": {
@@ -2198,11 +2205,12 @@
       "dev": true
     },
     "prom-client": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-13.0.0.tgz",
-      "integrity": "sha512-M7ZNjIO6x+2R/vjSD13yjJPjpoZA8eEwH2Bp2Re0/PvzozD7azikv+SaBtZes4Q1ca/xHjZ4RSCuTag3YZLg1A==",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.0.tgz",
+      "integrity": "sha512-cCD7jLTqyPdjEPBo/Xk4Iu8jxjuZgZJ3e/oET3L+ZwOuap/7Cw3dH/TJSsZKs1TQLZ2IHpIlRAKw82ef06kmMw==",
       "dev": true,
       "requires": {
+        "@opentelemetry/api": "^1.4.0",
         "tdigest": "^0.1.1"
       }
     },
@@ -2544,6 +2552,15 @@
       "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
       "dev": true
     },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -2552,15 +2569,6 @@
       "requires": {
         "is-fullwidth-code-point": "^2.0.0",
         "strip-ansi": "^4.0.0"
-      }
-    },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {

--- a/package.json
+++ b/package.json
@@ -38,13 +38,13 @@
     "jasme": "^6.0.0",
     "koa": "^2.6.2",
     "koa-connect": "^2.0.1",
-    "prom-client": "^13.0.0",
+    "prom-client": "^15.0.0",
     "supertest": "^3.3.0",
     "supertest-koa-agent": "^0.3.0",
     "typescript": "^3.4.5"
   },
   "peerDependencies": {
-    "prom-client": ">=12.0.0"
+    "prom-client": ">=15.0.0"
   },
   "repository": {
     "type": "git",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,7 +1,7 @@
 // TypeScript Version: 2.8
 
 import { Request, RequestHandler, Response, Express } from 'express';
-import { DefaultMetricsCollectorConfiguration, Registry } from 'prom-client';
+import { DefaultMetricsCollectorConfiguration, Registry, RegistryContentType } from 'prom-client';
 
 export {};
 
@@ -48,7 +48,7 @@ declare namespace express_prom_bundle {
 
     metricsPath?: string;
     httpDurationMetricName?: string;
-    promClient?: { collectDefaultMetrics?: DefaultMetricsCollectorConfiguration };
+    promClient?: { collectDefaultMetrics?: DefaultMetricsCollectorConfiguration<RegistryContentType> };
     promRegistry?: Registry;
     normalizePath?: NormalizePathEntry[] | NormalizePathFn;
     formatStatusCode?: NormalizeStatusCodeFn;


### PR DESCRIPTION
`prom-client` version 15 has breaking changes. 

Due to the `package.json` specifying the version as `^13.0.0` users will get a compile error when

1. Using node18 (incl. npm 10)
2. Deleting their `package-lock.json` 
3. Deleting `node_modules` and 
4. Running `npm i` afterwards

```
node_modules/express-prom-bundle/types/index.d.ts(51,44): 
error TS2314: 
Generic type 'DefaultMetricsCollectorConfiguration<T>' requires 1 type argument(s).
```

<img width="1466" alt="Screenshot 2024-01-04 at 13 24 29" src="https://github.com/jochen-schweizer/express-prom-bundle/assets/22643375/84a423df-74a5-403a-b8d4-3a739c50c919">


---

This MR will upgrade to the latest version and add the required type parameter