### PR TITLE
feat: add upMetricName params to allow for up metric name customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Which labels to include in `http_request_duration_seconds` metric:
 * **metricsPath**: replace the `/metrics` route with a **regex** or exact **string**. Note: it is highly recommended to just stick to the default
 * **metricType**: histogram/summary selection. See more details below
 * **httpDurationMetricName**: Allows you change the name of HTTP duration metric, default: **`http_request_duration_seconds`**.
+* **upMetricName**: Allows you change the name of up metric, default: **`up`**.
 
 ### metricType option ###
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "express-prom-bundle",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "express-prom-bundle",
-      "version": "8.0.0",
+      "version": "8.0.1",
       "license": "MIT",
       "dependencies": {
         "@types/express": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "express-prom-bundle",
-      "version": "7.0.2",
+      "version": "8.0.0",
       "license": "MIT",
       "dependencies": {
         "@types/express": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-prom-bundle",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "express middleware with popular prometheus metrics in one bundle",
   "main": "src/index.js",
   "keywords": [

--- a/src/index.js
+++ b/src/index.js
@@ -91,6 +91,7 @@ function main(opts) {
   }
 
   const httpMetricName = opts.httpDurationMetricName || 'http_request_duration_seconds';
+  const upMetricName = opts.upMetricName || 'up';
 
   function makeHttpMetric() {
     const labels = ['status_code'];
@@ -138,7 +139,7 @@ function main(opts) {
       prefix = opts.promClient.collectDefaultMetrics.prefix || '';
     }
     metrics.up = new promClient.Gauge({
-      name: `${prefix}up`,
+      name: prefix + upMetricName,
       help: '1 = up, 0 = not up',
       registers: [opts.promRegistry]
     });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -38,6 +38,7 @@ declare namespace express_prom_bundle {
 
     metricsPath?: string;
     httpDurationMetricName?: string;
+    upMetricName?: string;
     promClient?: { collectDefaultMetrics?: DefaultMetricsCollectorConfiguration<RegistryContentType> };
     promRegistry?: Registry;
     normalizePath?: NormalizePathEntry[] | NormalizePathFn;


### PR DESCRIPTION
This pull request introduces a new configuration option to customize the name of the "up" metric in the HTTP metrics library, enhancing flexibility for users. The most important changes include updates to the documentation, the addition of the new option in the code, and its integration into the metric creation logic.

### Documentation Updates:
* Added a description for the new `upMetricName` option in the `README.md`, which allows users to customize the name of the "up" metric. The default remains as `up`.

### Code Enhancements:
* Introduced the `upMetricName` configuration option in the `main` function of `src/index.js`, defaulting to `up` if not provided.
* Updated the metric creation logic to use the customizable `upMetricName` instead of the hardcoded `up`, ensuring the new option is applied when creating the "up" metric.

Fix the issue #122 